### PR TITLE
consistent dripline variable formting

### DIFF
--- a/library/agent.cc
+++ b/library/agent.cc
@@ -171,7 +171,7 @@ namespace dripline
 
         t_request->lockout_key() = f_agent->lockout_key();
 
-        LDEBUG( dlog, "Sending message w/ msgop = " << t_request->get_message_op() << " to " << t_request->routing_key() );
+        LDEBUG( dlog, "Sending message w/ msgop = " << t_request->get_message_operation() << " to " << t_request->routing_key() );
 
         sent_msg_pkg_ptr t_receive_reply;
         try

--- a/library/agent.cc
+++ b/library/agent.cc
@@ -45,7 +45,7 @@ namespace dripline
             f_specifier(),
             f_lockout_key( generate_nil_uuid() ),
             f_return_code( dl_success().rc_value() ),
-            f_return_msg(),
+            f_return_message(),
             f_timeout( 0 ),
             f_suppress_output( false ),
             f_json_print( false ),
@@ -112,7 +112,7 @@ namespace dripline
         if( t_config.has( "return" ) )
         {
             f_agent->set_return_code( t_config["return"].as_node().get_value( "code", dl_success().rc_value() ) );
-            f_agent->return_msg() = t_config["return"].as_node().get_value( "message", "" );
+            f_agent->return_message() = t_config["return"].as_node().get_value( "message", "" );
             t_config.erase( "return" );
         }
 
@@ -208,7 +208,7 @@ namespace dripline
 
                 LPROG( dlog, "Response:\n" <<
                         "Return code: " << t_reply->get_return_code() << '\n' <<
-                        "Return message: " << t_reply->return_msg() << '\n' <<
+                        "Return message: " << t_reply->return_message() << '\n' <<
                         t_payload );
 
                 if( ! f_agent->get_suppress_output() )
@@ -260,7 +260,7 @@ namespace dripline
         param_ptr_t t_payload_ptr( new param_node( a_config ) );
 
         reply_ptr_t t_reply =  msg_reply::create( f_agent->get_return_code(),
-                                                  f_agent->return_msg(),
+                                                  f_agent->return_message(),
                                                   std::move(t_payload_ptr),
                                                   f_agent->routing_key(),
                                                   f_agent->specifier() );
@@ -281,7 +281,7 @@ namespace dripline
             return;
         }
 
-        LDEBUG( dlog, "Sending reply with return code <" << t_reply->get_return_code() << "> and message <" << t_reply->return_msg() << "> to key " << t_reply->routing_key() );
+        LDEBUG( dlog, "Sending reply with return code <" << t_reply->get_return_code() << "> and message <" << t_reply->return_message() << "> to key " << t_reply->routing_key() );
 
         sent_msg_pkg_ptr t_msg_sent;
         try

--- a/library/agent.cc
+++ b/library/agent.cc
@@ -171,7 +171,7 @@ namespace dripline
 
         t_request->lockout_key() = f_agent->lockout_key();
 
-        LDEBUG( dlog, "Sending message w/ msgop = " << t_request->get_message_operation() << " to " << t_request->routing_key() );
+        LDEBUG( dlog, "Sending message w/ message_operation = " << t_request->get_message_operation() << " to " << t_request->routing_key() );
 
         sent_msg_pkg_ptr t_receive_reply;
         try

--- a/library/agent.hh
+++ b/library/agent.hh
@@ -145,7 +145,7 @@ namespace dripline
 
             // alerts only
             mv_accessible( unsigned, return_code );
-            mv_referrable( std::string, return_msg );
+            mv_referrable( std::string, return_message );
 
             // use only for requests
             mv_accessible( unsigned, timeout );

--- a/library/dripline_constants.cc
+++ b/library/dripline_constants.cc
@@ -32,8 +32,6 @@ namespace dripline
         switch (an_op) {
             case op_t::set: return "set";
             case op_t::get: return "get";
-            case op_t::config: return "config";//config is deprecated
-            case op_t::send: return "send";
             case op_t::run: return "run";
             case op_t::cmd: return "cmd";
             case op_t::unknown: return "unknown";
@@ -44,8 +42,6 @@ namespace dripline
     {
         if ( an_op_str == to_string( op_t::set ) ) return op_t::set;
         if ( an_op_str == to_string( op_t::get ) ) return op_t::get;
-        if ( an_op_str == to_string( op_t::config ) ) return op_t::config;
-        if ( an_op_str == to_string( op_t::send ) ) return op_t::send;
         if ( an_op_str == to_string( op_t::run ) ) return op_t::run;
         if ( an_op_str == to_string( op_t::cmd ) ) return op_t::cmd;
         if ( an_op_str == to_string( op_t::unknown ) ) return op_t::unknown;

--- a/library/dripline_constants.hh
+++ b/library/dripline_constants.hh
@@ -30,8 +30,6 @@ namespace dripline
     enum class DRIPLINE_API op_t:uint32_t {
             set = 0,
             get = 1,
-            config = 6, // deprecated as of v2.0.0
-            send = 7,
             run = 8,
             cmd = 9,
             unknown = UINT32_MAX

--- a/library/dripline_exceptions.cc
+++ b/library/dripline_exceptions.cc
@@ -20,19 +20,19 @@ namespace dripline
 
     throw_reply::throw_reply() :
             base_exception< throw_reply >(),
-            f_retcode( new dl_unhandled_exception() ),
+            f_return_code( new dl_unhandled_exception() ),
             f_payload( new scarab::param() )
     {}
 
     throw_reply::throw_reply( const return_code& a_code, scarab::param_ptr_t&& a_payload_ptr ) :
             base_exception< throw_reply >(),
-            f_retcode( new copy_code( a_code ) ),
+            f_return_code( new copy_code( a_code ) ),
             f_payload( std::move(a_payload_ptr) )
     {}
 
     throw_reply::throw_reply( const throw_reply& a_throw ) :
             base_exception< throw_reply >( a_throw ),
-            f_retcode( a_throw.f_retcode ),
+            f_return_code( a_throw.f_return_code ),
             f_payload( a_throw.f_payload->clone() )
     {}
 

--- a/library/dripline_exceptions.hh
+++ b/library/dripline_exceptions.hh
@@ -101,7 +101,7 @@ namespace dripline
             const scarab::param_ptr_t& get_payload_ptr() const;
 
         protected:
-            std::shared_ptr< return_code > f_retcode;
+            std::shared_ptr< return_code > f_return_code;
             scarab::param_ptr_t f_payload;
     };
 
@@ -154,12 +154,12 @@ namespace dripline
 
     inline const return_code& throw_reply::ret_code() const
     {
-        return *f_retcode;
+        return *f_return_code;
     }
 
     inline void throw_reply::set_return_code( const return_code& a_code )
     {
-        f_retcode.reset( new copy_code( a_code ) );
+        f_return_code.reset( new copy_code( a_code ) );
         return;
     }
 

--- a/library/endpoint.cc
+++ b/library/endpoint.cc
@@ -150,7 +150,7 @@ namespace dripline
         {
             LWARN( dlog, "Not sending reply (reply-to empty)\n" <<
                          "    Return code: " << t_reply->get_return_code() << '\n' <<
-                         "    Return message: " << t_reply->return_msg() << '\n' <<
+                         "    Return message: " << t_reply->return_message() << '\n' <<
                          "    Payload:\n" << t_reply->payload() );
         }
         else
@@ -191,7 +191,7 @@ namespace dripline
 
         LDEBUG( dlog, "Sending reply message to <" << a_reply->routing_key() << ">:\n" <<
                  "    Return code: " << a_reply->get_return_code() << '\n' <<
-                 "    Return message: " << a_reply->return_msg() << '\n' <<
+                 "    Return message: " << a_reply->return_message() << '\n' <<
                  "    Payload:\n" << a_reply->payload() );
 
         if( ! f_service->send( a_reply ) )

--- a/library/endpoint.cc
+++ b/library/endpoint.cc
@@ -99,7 +99,7 @@ namespace dripline
                 throw throw_reply( dl_message_error_invalid_key{} ) << "Lockout key could not be parsed";
             }
 
-            switch( a_request->get_message_op() )
+            switch( a_request->get_message_operation() )
             {
                 case op_t::run:
                 {

--- a/library/message.cc
+++ b/library/message.cc
@@ -224,14 +224,14 @@ namespace dripline
 
         // Create the message, of whichever type
         message_ptr_t t_message;
-        msg_t t_msg_type = to_msg_t( at( t_properties, std::string("msgtype"), TableValue(to_uint(msg_t::unknown)) ).GetUint32() );
+        msg_t t_msg_type = to_msg_t( at( t_properties, std::string("message_type"), TableValue(to_uint(msg_t::unknown)) ).GetUint32() );
         switch( t_msg_type )
         {
             case msg_t::request:
             {
                 request_ptr_t t_request = msg_request::create(
                         std::move(t_payload),
-                        to_op_t( at( t_properties, std::string("msgop"), TableValue(to_uint(op_t::unknown)) ).GetUint32() ),
+                        to_op_t( at( t_properties, std::string("message_operation"), TableValue(to_uint(op_t::unknown)) ).GetUint32() ),
                         a_routing_key,
                         at( t_properties, std::string("specifier"), TableValue("") ).GetString(),
                         t_first_valid_message->ReplyTo(),
@@ -247,8 +247,8 @@ namespace dripline
             case msg_t::reply:
             {
                 reply_ptr_t t_reply = msg_reply::create(
-                        at( t_properties, std::string("retcode"), TableValue(999U) ).GetUint32(),
-                        at( t_properties, std::string("return_msg"), TableValue("") ).GetString(),
+                        at( t_properties, std::string("return_code"), TableValue(999U) ).GetUint32(),
+                        at( t_properties, std::string("return_message"), TableValue("") ).GetString(),
                         std::move(t_payload),
                         a_routing_key,
                         at( t_properties, std::string("specifier"), TableValue("") ).GetString(),
@@ -326,7 +326,7 @@ namespace dripline
                 t_message->ReplyTo( f_reply_to );
 
                 AmqpClient::Table t_properties;
-                t_properties.insert( AmqpClient::TableEntry( "msgtype", to_uint(message_type()) ) );
+                t_properties.insert( AmqpClient::TableEntry( "message_type", to_uint(message_type()) ) );
                 t_properties.insert( AmqpClient::TableEntry( "specifier", f_specifier.to_string() ) );
                 t_properties.insert( AmqpClient::TableEntry( "timestamp", f_timestamp ) );
                 t_properties.insert( AmqpClient::TableEntry( "sender_info", param_to_table( get_sender_info() ) ) );
@@ -670,7 +670,7 @@ namespace dripline
         a_os << static_cast< const message& >( a_message );
         a_os << "Lockout Key: " << a_message.lockout_key() << '\n';
         a_os << "Lockout Key Valid: " << a_message.get_lockout_key_valid() << '\n';
-        a_os << "Message Op: " << a_message.get_message_op() << '\n';
+        a_os << "Message Operation: " << a_message.get_message_op() << '\n';
         return a_os;
     }
 

--- a/library/message.cc
+++ b/library/message.cc
@@ -524,15 +524,15 @@ namespace dripline
 
     }
 
-    reply_ptr_t msg_reply::create( const return_code& a_retcode, const std::string& a_ret_msg, param_ptr_t a_payload, const std::string& a_routing_key, const std::string& a_specifier, message::encoding a_encoding )
+    reply_ptr_t msg_reply::create( const return_code& a_return_code, const std::string& a_ret_msg, param_ptr_t a_payload, const std::string& a_routing_key, const std::string& a_specifier, message::encoding a_encoding )
     {
-        return msg_reply::create( a_retcode.rc_value(), a_ret_msg, std::move(a_payload), a_routing_key, a_specifier, a_encoding );
+        return msg_reply::create( a_return_code.rc_value(), a_ret_msg, std::move(a_payload), a_routing_key, a_specifier, a_encoding );
     }
 
-    reply_ptr_t msg_reply::create( unsigned a_retcode_value, const std::string& a_ret_msg, param_ptr_t a_payload, const std::string& a_routing_key, const std::string& a_specifier, message::encoding a_encoding )
+    reply_ptr_t msg_reply::create( unsigned a_return_code_value, const std::string& a_ret_msg, param_ptr_t a_payload, const std::string& a_routing_key, const std::string& a_specifier, message::encoding a_encoding )
     {
         reply_ptr_t t_reply = make_shared< msg_reply >();
-        t_reply->set_return_code( a_retcode_value );
+        t_reply->set_return_code( a_return_code_value );
         t_reply->return_msg() = a_ret_msg;
         t_reply->set_payload( std::move(a_payload) );
         t_reply->routing_key() = a_routing_key;

--- a/library/message.cc
+++ b/library/message.cc
@@ -231,7 +231,7 @@ namespace dripline
             {
                 request_ptr_t t_request = msg_request::create(
                         std::move(t_payload),
-                        to_op_t( at( t_properties, std::string("message_operation"), TableValue(to_uint(op_t::unknown)) ).GetUint32() ),
+                        to_op_t( at( t_properties, std::string("message_operationeration"), TableValue(to_uint(op_t::unknown)) ).GetUint32() ),
                         a_routing_key,
                         at( t_properties, std::string("specifier"), TableValue("") ).GetString(),
                         t_first_valid_message->ReplyTo(),
@@ -477,7 +477,7 @@ namespace dripline
             message(),
             f_lockout_key( generate_nil_uuid() ),
             f_lockout_key_valid( true ),
-            f_message_op( op_t::unknown )
+            f_message_operation( op_t::unknown )
     {
         f_correlation_id = string_from_uuid( generate_random_uuid() );
     }
@@ -491,7 +491,7 @@ namespace dripline
     {
         request_ptr_t t_request = make_shared< msg_request >();
         t_request->set_payload( std::move(a_payload) );
-        t_request->set_message_op( a_msg_op );
+        t_request->set_message_operation( a_msg_op );
         t_request->routing_key() = a_routing_key;
         t_request->parsed_specifier() = a_specifier;
         t_request->reply_to() = a_reply_to;
@@ -615,7 +615,7 @@ namespace dripline
         return operator==( static_cast< const message& >(a_lhs), static_cast< const message& >(a_rhs) ) &&
                 a_lhs.lockout_key() == a_rhs.lockout_key() &&
                 a_lhs.get_lockout_key_valid() == a_rhs.get_lockout_key_valid() &&
-                a_lhs.get_message_op() == a_rhs.get_message_op();
+                a_lhs.get_message_operation() == a_rhs.get_message_operation();
     }
 
     DRIPLINE_API bool operator==( const msg_reply& a_lhs, const msg_reply& a_rhs )
@@ -670,7 +670,7 @@ namespace dripline
         a_os << static_cast< const message& >( a_message );
         a_os << "Lockout Key: " << a_message.lockout_key() << '\n';
         a_os << "Lockout Key Valid: " << a_message.get_lockout_key_valid() << '\n';
-        a_os << "Message Operation: " << a_message.get_message_op() << '\n';
+        a_os << "Message Operation: " << a_message.get_message_operation() << '\n';
         return a_os;
     }
 

--- a/library/message.cc
+++ b/library/message.cc
@@ -514,7 +514,7 @@ namespace dripline
     msg_reply::msg_reply() :
             message(),
             f_return_code( dl_success::s_value ),
-            f_return_msg(),
+            f_return_message(),
             f_return_buffer()
     {
     }
@@ -533,7 +533,7 @@ namespace dripline
     {
         reply_ptr_t t_reply = make_shared< msg_reply >();
         t_reply->set_return_code( a_return_code_value );
-        t_reply->return_msg() = a_ret_msg;
+        t_reply->return_message() = a_ret_msg;
         t_reply->set_payload( std::move(a_payload) );
         t_reply->routing_key() = a_routing_key;
         t_reply->parsed_specifier() = a_specifier;
@@ -622,7 +622,7 @@ namespace dripline
     {
         return operator==( static_cast< const message& >(a_lhs), static_cast< const message& >(a_rhs) ) &&
                 a_lhs.get_return_code() == a_rhs.get_return_code() &&
-                a_lhs.return_msg() == a_rhs.return_msg();
+                a_lhs.return_message() == a_rhs.return_message();
     }
 
     DRIPLINE_API bool operator==( const msg_alert& a_lhs, const msg_alert& a_rhs )
@@ -678,7 +678,7 @@ namespace dripline
     {
         a_os << static_cast< const message& >( a_message );
         a_os << "Return Code: " << a_message.get_return_code() << '\n';
-        a_os << "Return Message: " << a_message.return_msg() << '\n';
+        a_os << "Return Message: " << a_message.return_message() << '\n';
         return a_os;
     }
 

--- a/library/message.hh
+++ b/library/message.hh
@@ -171,7 +171,7 @@ namespace dripline
 
             mv_referrable( uuid_t, lockout_key );
             mv_accessible( bool, lockout_key_valid );
-            mv_accessible( op_t, message_op );
+            mv_accessible( op_t, message_operation );
 
     };
 
@@ -305,14 +305,14 @@ namespace dripline
 
     inline void msg_request::derived_modify_amqp_message( amqp_message_ptr /*a_amqp_msg*/, AmqpClient::Table& a_properties ) const
     {
-        a_properties.insert( AmqpClient::TableEntry( "message_operation", AmqpClient::TableValue(to_uint(f_message_op)) ) );
+        a_properties.insert( AmqpClient::TableEntry( "message_operationeration", AmqpClient::TableValue(to_uint(f_message_operation)) ) );
         a_properties.insert( AmqpClient::TableEntry( "lockout_key", AmqpClient::TableValue(string_from_uuid(lockout_key())) ) );
         return;
     }
 
     inline void msg_request::derived_modify_message_param( scarab::param_node& a_message_node ) const
     {
-        a_message_node.add( "message_operation", to_uint(f_message_op) );
+        a_message_node.add( "message_operationeration", to_uint(f_message_operation) );
         a_message_node.add( "lockout_key", string_from_uuid(lockout_key()) );
         return;
     }

--- a/library/message.hh
+++ b/library/message.hh
@@ -305,14 +305,14 @@ namespace dripline
 
     inline void msg_request::derived_modify_amqp_message( amqp_message_ptr /*a_amqp_msg*/, AmqpClient::Table& a_properties ) const
     {
-        a_properties.insert( AmqpClient::TableEntry( "msgop", AmqpClient::TableValue(to_uint(f_message_op)) ) );
+        a_properties.insert( AmqpClient::TableEntry( "message_operation", AmqpClient::TableValue(to_uint(f_message_op)) ) );
         a_properties.insert( AmqpClient::TableEntry( "lockout_key", AmqpClient::TableValue(string_from_uuid(lockout_key())) ) );
         return;
     }
 
     inline void msg_request::derived_modify_message_param( scarab::param_node& a_message_node ) const
     {
-        a_message_node.add( "msg_op", to_uint(f_message_op) );
+        a_message_node.add( "message_operation", to_uint(f_message_op) );
         a_message_node.add( "lockout_key", string_from_uuid(lockout_key()) );
         return;
     }
@@ -359,8 +359,8 @@ namespace dripline
 
     inline void msg_reply::derived_modify_amqp_message( amqp_message_ptr, AmqpClient::Table& a_properties ) const
     {
-        a_properties.insert( AmqpClient::TableEntry( "retcode", AmqpClient::TableValue(f_return_code) ) );
-        a_properties.insert( AmqpClient::TableEntry( "return_msg", AmqpClient::TableValue(f_return_msg) ) );
+        a_properties.insert( AmqpClient::TableEntry( "return_code", AmqpClient::TableValue(f_return_code) ) );
+        a_properties.insert( AmqpClient::TableEntry( "return_message", AmqpClient::TableValue(f_return_msg) ) );
         return;
     }
 

--- a/library/message.hh
+++ b/library/message.hh
@@ -208,7 +208,7 @@ namespace dripline
             mv_accessible_static_noset( msg_t, message_type );
 
             mv_accessible( unsigned, return_code );
-            mv_referrable( std::string, return_msg );
+            mv_referrable( std::string, return_message );
 
         private:
             mutable std::string f_return_buffer;
@@ -360,14 +360,14 @@ namespace dripline
     inline void msg_reply::derived_modify_amqp_message( amqp_message_ptr, AmqpClient::Table& a_properties ) const
     {
         a_properties.insert( AmqpClient::TableEntry( "return_code", AmqpClient::TableValue(f_return_code) ) );
-        a_properties.insert( AmqpClient::TableEntry( "return_message", AmqpClient::TableValue(f_return_msg) ) );
+        a_properties.insert( AmqpClient::TableEntry( "return_message", AmqpClient::TableValue(f_return_message) ) );
         return;
     }
 
     inline void msg_reply::derived_modify_message_param( scarab::param_node& a_message_node ) const
     {
         a_message_node.add( "return_code", f_return_code );
-        a_message_node.add( "return_message", f_return_msg );
+        a_message_node.add( "return_message", f_return_message );
         return;
     }
 

--- a/library/message.hh
+++ b/library/message.hh
@@ -158,8 +158,8 @@ namespace dripline
             bool is_reply() const;
             bool is_alert() const;
 
-            reply_ptr_t reply( const return_code& a_retcode, const std::string& a_ret_msg, scarab::param_ptr_t a_payload = scarab::param_ptr_t( new scarab::param() ) ) const;
-            reply_ptr_t reply( const unsigned a_retcode, const std::string& a_ret_msg, scarab::param_ptr_t a_payload = scarab::param_ptr_t( new scarab::param() ) ) const;
+            reply_ptr_t reply( const return_code& a_return_code, const std::string& a_ret_msg, scarab::param_ptr_t a_payload = scarab::param_ptr_t( new scarab::param() ) ) const;
+            reply_ptr_t reply( const unsigned a_return_code, const std::string& a_ret_msg, scarab::param_ptr_t a_payload = scarab::param_ptr_t( new scarab::param() ) ) const;
 
         private:
             void derived_modify_amqp_message( amqp_message_ptr a_amqp_msg, AmqpClient::Table& a_properties ) const;
@@ -190,10 +190,10 @@ namespace dripline
             msg_reply();
             virtual ~msg_reply();
 
-            static reply_ptr_t create( const return_code& a_retcode, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const std::string& a_routing_key, const std::string& a_specifier = "", message::encoding a_encoding = encoding::json );
-            static reply_ptr_t create( unsigned a_retcode_value, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const std::string& a_routing_key, const std::string& a_specifier = "", message::encoding a_encoding = encoding::json );
-            static reply_ptr_t create( const return_code& a_retcode, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const msg_request& a_request );
-            static reply_ptr_t create( unsigned a_retcode, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const msg_request& a_request );
+            static reply_ptr_t create( const return_code& a_return_code, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const std::string& a_routing_key, const std::string& a_specifier = "", message::encoding a_encoding = encoding::json );
+            static reply_ptr_t create( unsigned a_return_code_value, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const std::string& a_routing_key, const std::string& a_specifier = "", message::encoding a_encoding = encoding::json );
+            static reply_ptr_t create( const return_code& a_return_code, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const msg_request& a_request );
+            static reply_ptr_t create( unsigned a_return_code, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const msg_request& a_request );
 
             bool is_request() const;
             bool is_reply() const;
@@ -317,14 +317,14 @@ namespace dripline
         return;
     }
 
-    inline reply_ptr_t msg_request::reply( const return_code& a_retcode, const std::string& a_ret_msg, scarab::param_ptr_t a_payload ) const
+    inline reply_ptr_t msg_request::reply( const return_code& a_return_code, const std::string& a_ret_msg, scarab::param_ptr_t a_payload ) const
     {
-        return msg_reply::create( a_retcode, a_ret_msg, std::move(a_payload), *this );
+        return msg_reply::create( a_return_code, a_ret_msg, std::move(a_payload), *this );
     }
 
-    inline reply_ptr_t msg_request::reply( unsigned a_retcode, const std::string& a_ret_msg, scarab::param_ptr_t a_payload ) const
+    inline reply_ptr_t msg_request::reply( unsigned a_return_code, const std::string& a_ret_msg, scarab::param_ptr_t a_payload ) const
     {
-        return msg_reply::create( a_retcode, a_ret_msg, std::move(a_payload), *this );
+        return msg_reply::create( a_return_code, a_ret_msg, std::move(a_payload), *this );
     }
 
 
@@ -332,14 +332,14 @@ namespace dripline
     // Reply
     //*********
 
-    inline reply_ptr_t msg_reply::create( const return_code& a_retcode, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const msg_request& a_request )
+    inline reply_ptr_t msg_reply::create( const return_code& a_return_code, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const msg_request& a_request )
     {
-        return msg_reply::create( a_retcode.rc_value(), a_ret_msg, std::move(a_payload), a_request );
+        return msg_reply::create( a_return_code.rc_value(), a_ret_msg, std::move(a_payload), a_request );
     }
 
-    inline reply_ptr_t msg_reply::create( unsigned a_retcode, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const msg_request& a_request )
+    inline reply_ptr_t msg_reply::create( unsigned a_return_code, const std::string& a_ret_msg, scarab::param_ptr_t a_payload, const msg_request& a_request )
     {
-        reply_ptr_t t_reply = msg_reply::create( a_retcode, a_ret_msg, std::move(a_payload), a_request.reply_to(), "", a_request.get_encoding() );
+        reply_ptr_t t_reply = msg_reply::create( a_return_code, a_ret_msg, std::move(a_payload), a_request.reply_to(), "", a_request.get_encoding() );
         t_reply->correlation_id() = a_request.correlation_id();
         return t_reply;
     }

--- a/library/service.cc
+++ b/library/service.cc
@@ -460,7 +460,7 @@ namespace dripline
     {
         LDEBUG( dlog, "Sending reply message to <" << a_reply->routing_key() << ">:\n" <<
                  "    Return code: " << a_reply->get_return_code() << '\n' <<
-                 "    Return message: " << a_reply->return_msg() << '\n' <<
+                 "    Return message: " << a_reply->return_message() << '\n' <<
                  "    Payload:\n" << a_reply->payload() );
 
         if( ! send( a_reply ) )

--- a/testing/test_agent.cc
+++ b/testing/test_agent.cc
@@ -19,7 +19,7 @@ TEST_CASE( "sub_agent_run", "[agent]" )
 
     REQUIRE( t_request );
     REQUIRE( t_request->get_message_type() == dripline::msg_t::request );
-    REQUIRE( t_request->get_message_op() == dripline::op_t::run );
+    REQUIRE( t_request->get_message_operation() == dripline::op_t::run );
 }
 
 TEST_CASE( "sub_agent_get", "[agent]" )
@@ -32,7 +32,7 @@ TEST_CASE( "sub_agent_get", "[agent]" )
 
     REQUIRE( t_request );
     REQUIRE( t_request->get_message_type() == dripline::msg_t::request );
-    REQUIRE( t_request->get_message_op() == dripline::op_t::get );
+    REQUIRE( t_request->get_message_operation() == dripline::op_t::get );
 }
 
 TEST_CASE( "sub_agent_set", "[agent]" )
@@ -59,7 +59,7 @@ TEST_CASE( "sub_agent_set", "[agent]" )
 
         REQUIRE( t_request );
         REQUIRE( t_request->get_message_type() == dripline::msg_t::request );
-        REQUIRE( t_request->get_message_op() == dripline::op_t::set );
+        REQUIRE( t_request->get_message_operation() == dripline::op_t::set );
         REQUIRE( t_request->payload().is_node() );
         REQUIRE( ! t_request->payload().as_node().empty() );
         REQUIRE( t_request->payload().as_node().has( "values" ) );
@@ -77,7 +77,7 @@ TEST_CASE( "sub_agent_cmd", "[agent]" )
 
     REQUIRE( t_request );
     REQUIRE( t_request->get_message_type() == dripline::msg_t::request );
-    REQUIRE( t_request->get_message_op() == dripline::op_t::cmd );
+    REQUIRE( t_request->get_message_operation() == dripline::op_t::cmd );
 }
 
 TEST_CASE( "agent", "[agent]" )

--- a/testing/test_endpoint.cc
+++ b/testing/test_endpoint.cc
@@ -22,15 +22,15 @@ TEST_CASE( "submit_msg", "[endpoint]" )
 
     REQUIRE_NOTHROW( t_endpoint.submit_request_message( t_request_ptr ) );
 
-    t_request_ptr->set_message_op( dripline::op_t::get );
+    t_request_ptr->set_message_operation( dripline::op_t::get );
 
     REQUIRE_NOTHROW( t_endpoint.submit_request_message( t_request_ptr ) );
 
-    t_request_ptr->set_message_op( dripline::op_t::set );
+    t_request_ptr->set_message_operation( dripline::op_t::set );
 
     REQUIRE_NOTHROW( t_endpoint.submit_request_message( t_request_ptr ) );
 
-    t_request_ptr->set_message_op( dripline::op_t::cmd );
+    t_request_ptr->set_message_operation( dripline::op_t::cmd );
 
     REQUIRE_NOTHROW( t_endpoint.submit_request_message( t_request_ptr ) );
 

--- a/testing/test_messages.cc
+++ b/testing/test_messages.cc
@@ -31,7 +31,7 @@ TEST_CASE( "message", "[message]" )
     REQUIRE( t_req_ptr->get_is_valid() );
     REQUIRE( t_req_ptr->routing_key() == t_routing_key );
     REQUIRE_FALSE( t_req_ptr->correlation_id().empty() );
-    REQUIRE( t_req_ptr->get_message_op() == dripline::op_t::cmd );
+    REQUIRE( t_req_ptr->get_message_operation() == dripline::op_t::cmd );
     REQUIRE( t_req_ptr->sender_versions().count("dripline") == 1 );
     REQUIRE( t_req_ptr->sender_versions().count("dripline-cpp") == 1 );
     REQUIRE( t_req_ptr->sender_versions().at("dripline-cpp").f_package == "driplineorg/dripline-cpp" );


### PR DESCRIPTION
Changed instances of dripline wire protocols into consistent naming scheme. 

I did not change all (internal) instances of the variables/ functions, as I didnt think this could ever be done totally consistently