### PR TITLE
Feature/direct submit

### DIFF
--- a/library/service.hh
+++ b/library/service.hh
@@ -153,9 +153,6 @@ namespace dripline
             /// Waits for AMQP messages arriving on the channel
             virtual bool listen_on_queue();
 
-            /// Submit a message for direct processing
-            virtual void submit_message( message_ptr_t a_message );
-
             /// Sends a reply message
             virtual void send_reply( reply_ptr_t a_reply ) const;
 
@@ -171,6 +168,9 @@ namespace dripline
             mv_referrable( std::string, broadcast_key );
 
         protected:
+            /// Implementation of submit_message (from concurrent_receiver)
+            virtual void submit_message( message_ptr_t a_message );
+
             virtual reply_ptr_t on_request_message( const request_ptr_t a_request );
 
         private:

--- a/library/service.hh
+++ b/library/service.hh
@@ -68,6 +68,9 @@ namespace dripline
        * Async endpoint receiver -- same as above for each asynchronous endpoint
        * Heatbeater -- sends regular heartbeat messages
        * Scheduler -- executes scheduled events
+
+     In addition to receiving messages from the broker, a user or client code can give messages directly to the service 
+     using `process_message(message)`.
     */
     class DRIPLINE_API service :
             public core,

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -18,6 +18,7 @@ set( testing_SOURCES
     test_messages.cc
     test_return_codes.cc
     test_scheduler.cc
+    test_service.cc
     test_specifier.cc
     test_throw_reply.cc
     test_version_store.cc

--- a/testing/test_service.cc
+++ b/testing/test_service.cc
@@ -1,0 +1,43 @@
+/*
+ * test_service.cc
+ *
+ *  Created on: Jun 10, 2021
+ *      Author: N.S. Oblath
+ */
+
+#include "dripline_exceptions.hh"
+#include "service.hh"
+
+#include "catch.hpp"
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+TEST_CASE( "process_message", "[service]" )
+{
+    dripline::service t_service;
+
+    dripline::request_ptr_t t_request_ptr = dripline::msg_request::create( scarab::param_ptr_t( new scarab::param() ), dripline::op_t::get, "dlcpp_service", "", "" );
+
+    // we process the message before executing the concurrent_receiver.
+    // this means the message will be queued.
+    t_service.process_message( t_request_ptr );
+    REQUIRE( t_service.message_queue().size() == 1 );
+
+    // here we launch the execution asynchronously.
+    // we'll give it 1 second to execute, which should be enough, though in principle it's not a 100% guarantee that it'll be done in time.
+    // we then cancel the service and move on to verify that the queue is empty.
+    auto t_do_execute = [&](){ t_service.concurrent_receiver::execute(); };
+    auto t_exe_future = std::async(std::launch::async, t_do_execute);
+    std::this_thread::sleep_for( std::chrono::seconds(1) );
+    t_service.cancel();
+    t_exe_future.wait();
+
+    REQUIRE( t_service.message_queue().empty() );
+
+}
+
+
+
+


### PR DESCRIPTION
Refined direct submission of messages to a service.  Service already was setup to use a concurrent queue for message processing.  I made `service::submit_message()` protected to remove it from the API, since users/client code should really use `concurrent_receiver::process_message()` instead.

I added the test program test_service.cc to include a test of the asynchronous message processing.