### PR TITLE
Hotfix/2.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required (VERSION 3.12)
 #########
 
 cmake_policy( SET CMP0048 NEW ) # version in project()
-project( Dripline VERSION 2.8.0 )
+project( Dripline VERSION 2.8.1 )
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/scarab/cmake )
 

--- a/examples/oscillator_service_endpoints.cc
+++ b/examples/oscillator_service_endpoints.cc
@@ -174,6 +174,7 @@ namespace dripline
         {
             LERROR( dlog, "Exception caught: " << e.what() );
             f_return = dl_service_error().rc_value() / 100;
+            scarab::signal_handler::cancel_all( f_return );
         }
 
         if( scarab::signal_handler::get_exited() )

--- a/examples/oscillator_service_hub.cc
+++ b/examples/oscillator_service_hub.cc
@@ -63,6 +63,7 @@ namespace dripline
         {
             LERROR( dlog, "Exception caught: " << e.what() );
             f_return = dl_service_error().rc_value() / 100;
+            scarab::signal_handler::cancel_all( f_return );
         }
 
         if( scarab::signal_handler::get_exited() )

--- a/examples/simple_service.cc
+++ b/examples/simple_service.cc
@@ -53,6 +53,7 @@ namespace dripline
         {
             LERROR( dlog, "Exception caught: " << e.what() );
             f_return = dl_service_error().rc_value() / 100;
+            scarab::signal_handler::cancel_all( f_return );
         }
 
         if( scarab::signal_handler::get_exited() )

--- a/executables/dl-mon.cc
+++ b/executables/dl-mon.cc
@@ -61,11 +61,16 @@ int main( int argc, char** argv )
 
         auto the_monitor = std::make_shared< monitor >( the_main.primary_config() );
 
-        if( ! the_monitor->start() ) return;
+        // run each phase of the operation, while checking for errors
+        if ( ! the_monitor->start() || 
+             ! the_monitor->listen() ||
+             ! the_monitor->stop() )
+        {
+            scarab::signal_handler::cancel_all( RETURN_ERROR );
+        }
 
-        if( ! the_monitor->listen() ) return;
-
-        if( ! the_monitor->stop() ) return;
+        // brief pause to ensure that the cancellation goes through
+        std::this_thread::sleep_for( std::chrono::milliseconds(100) );
 
         the_return = scarab::signal_handler::get_exited() ? 
                 scarab::signal_handler::get_return_code() : dl_success().rc_value() / 100;

--- a/library/listener.hh
+++ b/library/listener.hh
@@ -55,6 +55,7 @@ namespace dripline
             listener& operator=( const listener& ) = delete;
             listener& operator=( listener&& a_orig );
 
+            /// Returns false if the return is due to an error in this function; returns true otherwise (namely because it was canceled)
             virtual bool listen_on_queue() = 0;
 
             mv_referrable( amqp_channel_ptr, channel );
@@ -113,6 +114,7 @@ namespace dripline
             endpoint_listener_receiver& operator=( endpoint_listener_receiver&& a_orig );
 
             /// Listens for AMQP messages and then passes them to be handled as Dripline message chunks
+            /// Returns false if the return is due to an error in this function; returns true otherwise (namely because it was canceled)
             virtual bool listen_on_queue();
 
         protected:

--- a/library/monitor.cc
+++ b/library/monitor.cc
@@ -166,7 +166,7 @@ namespace dripline
 
             if( ! listen_on_queue() )
             {
-                scarab::signal_handler::cancel_all(RETURN_ERROR);
+                throw dripline_error() << "Something went wrong while listening for messages";
             }
 
             f_receiver_thread.join();

--- a/library/monitor.cc
+++ b/library/monitor.cc
@@ -164,7 +164,10 @@ namespace dripline
         {
             f_receiver_thread = std::thread( &concurrent_receiver::execute, this );
 
-            listen_on_queue();
+            if( ! listen_on_queue() )
+            {
+                scarab::signal_handler::cancel_all(RETURN_ERROR);
+            }
 
             f_receiver_thread.join();
         }

--- a/library/monitor.hh
+++ b/library/monitor.hh
@@ -93,6 +93,7 @@ namespace DRIPLINE_API dripline
 
         public:
             /// Waits for a single AMQP message and processes it.
+            /// Returns false if the return is due to an error in this function; returns true otherwise (namely because it was canceled)
             virtual bool listen_on_queue();
 
             /// Handles a single Dripline message by printing it to stdout.

--- a/library/receiver.cc
+++ b/library/receiver.cc
@@ -453,7 +453,7 @@ namespace dripline
         {
             // shutdown gracefully on an exception
             LERROR( dlog, "Exception caught; shutting down.\n" << "\t" << e.what() );
-            scarab::signal_handler::cancel_all( 1 );
+            scarab::signal_handler::cancel_all( RETURN_ERROR );
         }
     }
 

--- a/library/service.cc
+++ b/library/service.cc
@@ -13,6 +13,7 @@
 
 #include "authentication.hh"
 #include "logger.hh"
+#include "signal_handler.hh"
 
 using scarab::authentication;
 using scarab::param_node;
@@ -224,15 +225,23 @@ namespace dripline
 
             f_receiver_thread = std::thread( &concurrent_receiver::execute, this );
 
+            // lambda to cancel everything on an error from listener::listen_on_queue()
+            auto t_cancel_on_listen_error = [](listener& a_listener) {
+                if( ! a_listener.listen_on_queue() )
+                {
+                    scarab::signal_handler::cancel_all(RETURN_ERROR);
+                }
+            };
+
             for( async_map_t::iterator t_child_it = f_async_children.begin();
                     t_child_it != f_async_children.end();
                     ++t_child_it )
             {
                 t_child_it->second->receiver_thread() = std::thread( &concurrent_receiver::execute, static_cast< listener_receiver* >(t_child_it->second.get()) );
-                t_child_it->second->listener_thread() = std::thread( &listener::listen_on_queue, t_child_it->second.get() );
+                t_child_it->second->listener_thread() = std::thread( t_cancel_on_listen_error, std::ref(*t_child_it->second.get()) );
             }
 
-            listen_on_queue();
+            t_cancel_on_listen_error( *this );
 
             for( async_map_t::iterator t_child_it = f_async_children.begin();
                     t_child_it != f_async_children.end();

--- a/library/service.hh
+++ b/library/service.hh
@@ -126,14 +126,17 @@ namespace dripline
         public:
             /// Creates a channel to the broker and establishes the queue for receiving messages.
             /// If no queue name was given, this does nothing.
+            /// If this returns false, the service should quit with an error
             bool start();
 
             /// Starts listening on the queue for receiving messages.
             /// If no queue was created, this does nothing.
+            /// If this returns false, the service should quit with an error
             bool listen();
 
             /// Stops receiving messages and closes the connection to the broker.
             /// If no queue was created, this does nothing.
+            /// If this returns false, the service should quit with an error
             bool stop();
 
         protected:

--- a/library/service.hh
+++ b/library/service.hh
@@ -151,6 +151,7 @@ namespace dripline
 
         public:
             /// Waits for AMQP messages arriving on the channel
+            /// Returns false if the return is due to an error in this function; returns true otherwise (namely because it was canceled)
             virtual bool listen_on_queue();
 
             /// Sends a reply message


### PR DESCRIPTION
Based on reports from Raphael I identified a bug in dl-cpp where Rabbitmq errors that happened while listening for messages were being ignored.  These errors are generated by the `listen_on_queue()` function, and returned false from that function.  But the return values were being ignored everywhere it was used.  I fixed that in `service` and `monitor`.