### PR TITLE
accept signed integers for message_type, message_operation, and return_code

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -166,9 +166,9 @@ jobs:
           ./run_dl_tests
 
 # For debugging
-      - name: Setup tmate session
-        if: ${{ ! success() }}
-        uses: mxschmitt/action-tmate@v3
+#      - name: Setup tmate session
+#        if: ${{ ! success() }}
+#        uses: mxschmitt/action-tmate@v3
 
 
   build_and_push:

--- a/library/dripline_constants.cc
+++ b/library/dripline_constants.cc
@@ -14,17 +14,17 @@ namespace dripline
 {
     // op_t utility functions
     // Conversion functions for use when a numeric value is needed
-    DRIPLINE_API uint32_t to_uint( op_t an_op )
+    DRIPLINE_API int to_int( op_t an_op )
     {
-        return static_cast< uint32_t >( an_op );
+        return static_cast< int >( an_op );
     }
-    DRIPLINE_API op_t to_op_t( uint32_t an_op_uint )
+    DRIPLINE_API op_t to_op_t( int an_op_int )
     {
-        return static_cast< op_t >( an_op_uint );
+        return static_cast< op_t >( an_op_int );
     }
     DRIPLINE_API std::ostream& operator<<( std::ostream& a_os, op_t an_op )
     {
-        return a_os << to_uint( an_op );
+        return a_os << to_int( an_op );
     }
     // Conversion functions for use when string values are required
     DRIPLINE_API std::string to_string( op_t an_op )
@@ -48,17 +48,17 @@ namespace dripline
 
     // msg_t utility functions
     // Conversion functions for use when a numeric value is needed
-    DRIPLINE_API uint32_t to_uint( msg_t a_msg )
+    DRIPLINE_API int to_int( msg_t a_msg )
     {
-        return static_cast< uint32_t >( a_msg );
+        return static_cast< int >( a_msg );
     }
-    DRIPLINE_API msg_t to_msg_t( uint32_t a_msg_uint )
+    DRIPLINE_API msg_t to_msg_t( int a_msg_int )
     {
-        return static_cast< msg_t >( a_msg_uint );
+        return static_cast< msg_t >( a_msg_int );
     }
     DRIPLINE_API std::ostream& operator<<( std::ostream& a_os, msg_t a_msg )
     {
-        return a_os << to_uint( a_msg );
+        return a_os << to_int( a_msg );
     }
     // Conversion functions for use when string values are required
     DRIPLINE_API std::string to_string( msg_t a_msg )

--- a/library/dripline_constants.hh
+++ b/library/dripline_constants.hh
@@ -30,18 +30,18 @@ namespace dripline
         \enum op_t
         Message Operations
     */
-    enum class DRIPLINE_API op_t:uint32_t {
+    enum class DRIPLINE_API op_t:int {
             set = 0,
             get = 1,
             cmd = 9,
-            unknown = UINT32_MAX
+            unknown = INT_MAX
     };
 
     /// Convert a message-operation enum to an integer
-    DRIPLINE_API uint32_t to_uint( op_t an_op );
+    DRIPLINE_API int to_int( op_t an_op );
     /// Convert an integer to a message-operation enum
     /// The result is unspecified for invalid integers
-    DRIPLINE_API op_t to_op_t( uint32_t an_op_uint );
+    DRIPLINE_API op_t to_op_t( int an_op_int );
     /// Pass the integer-equivalent of a message-operation enum to an ostream
     DRIPLINE_API std::ostream& operator<<( std::ostream& a_os, op_t an_op );
     /// Gives the human-readable version of a message operation
@@ -54,19 +54,19 @@ namespace dripline
         \enum msg_t
         Message Types
     */
-    enum class DRIPLINE_API msg_t:uint32_t
+    enum class DRIPLINE_API msg_t:int
     {
         reply = 2,
         request = 3,
         alert = 4,
-        unknown = UINT32_MAX
+        unknown = INT_MAX
     };
 
     /// Convert a message-type enum to an integer
-    DRIPLINE_API uint32_t to_uint( msg_t a_msg );
+    DRIPLINE_API int to_int( msg_t a_msg );
     /// Convert an integer to a message-type enum
     /// The result is unspecified for invalid integers
-    DRIPLINE_API msg_t to_msg_t( uint32_t a_msg_uint );
+    DRIPLINE_API msg_t to_msg_t( int a_msg_int );
     /// Pass the integer-equivalent of a message-type enum to an ostream
     DRIPLINE_API std::ostream& operator<<( std::ostream& a_os, msg_t a_msg );
     /// Gives the human-readable version of the message type

--- a/library/dripline_constants.hh
+++ b/library/dripline_constants.hh
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <climits>
 #include <ostream>
 
 namespace dripline

--- a/library/message.cc
+++ b/library/message.cc
@@ -221,14 +221,14 @@ namespace dripline
 
         // Create the message, of whichever type
         message_ptr_t t_message;
-        msg_t t_msg_type = to_msg_t( at( t_properties, std::string("message_type"), TableValue(to_uint(msg_t::unknown)) ).GetUint32() );
+        msg_t t_msg_type = to_msg_t( at( t_properties, std::string("message_type"), TableValue(to_uint(msg_t::unknown)) ).GetInteger() );
         switch( t_msg_type )
         {
             case msg_t::request:
             {
                 request_ptr_t t_request = msg_request::create(
                         std::move(t_payload),
-                        to_op_t( at( t_properties, std::string("message_operation"), TableValue(to_uint(op_t::unknown)) ).GetUint32() ),
+                        to_op_t( at( t_properties, std::string("message_operation"), TableValue(to_uint(op_t::unknown)) ).GetInteger() ),
                         a_routing_key,
                         at( t_properties, std::string("specifier"), TableValue("") ).GetString(),
                         t_first_valid_message->ReplyTo(),
@@ -244,7 +244,7 @@ namespace dripline
             case msg_t::reply:
             {
                 reply_ptr_t t_reply = msg_reply::create(
-                        at( t_properties, std::string("return_code"), TableValue(999U) ).GetUint32(),
+                        at( t_properties, std::string("return_code"), TableValue(999U) ).GetInteger(),
                         at( t_properties, std::string("return_message"), TableValue("") ).GetString(),
                         std::move(t_payload),
                         a_routing_key,

--- a/library/message.cc
+++ b/library/message.cc
@@ -221,14 +221,14 @@ namespace dripline
 
         // Create the message, of whichever type
         message_ptr_t t_message;
-        msg_t t_msg_type = to_msg_t( at( t_properties, std::string("message_type"), TableValue(to_uint(msg_t::unknown)) ).GetInteger() );
+        msg_t t_msg_type = to_msg_t( at( t_properties, std::string("message_type"), TableValue(to_int(msg_t::unknown)) ).GetInteger() );
         switch( t_msg_type )
         {
             case msg_t::request:
             {
                 request_ptr_t t_request = msg_request::create(
                         std::move(t_payload),
-                        to_op_t( at( t_properties, std::string("message_operation"), TableValue(to_uint(op_t::unknown)) ).GetInteger() ),
+                        to_op_t( at( t_properties, std::string("message_operation"), TableValue(to_int(op_t::unknown)) ).GetInteger() ),
                         a_routing_key,
                         at( t_properties, std::string("specifier"), TableValue("") ).GetString(),
                         t_first_valid_message->ReplyTo(),
@@ -323,7 +323,7 @@ namespace dripline
                 t_message->ReplyTo( f_reply_to );
 
                 AmqpClient::Table t_properties;
-                t_properties.insert( AmqpClient::TableEntry( "message_type", to_uint(message_type()) ) );
+                t_properties.insert( AmqpClient::TableEntry( "message_type", to_int(message_type()) ) );
                 t_properties.insert( AmqpClient::TableEntry( "specifier", f_specifier.to_string() ) );
                 t_properties.insert( AmqpClient::TableEntry( "timestamp", f_timestamp ) );
                 t_properties.insert( AmqpClient::TableEntry( "sender_info", param_to_table( get_sender_info() ) ) );
@@ -456,7 +456,7 @@ namespace dripline
         t_message_node.add( "correlation_id", f_correlation_id );
         t_message_node.add( "message_id", f_message_id );
         t_message_node.add( "reply_to", f_reply_to );
-        t_message_node.add( "message_type", to_uint(message_type()) );
+        t_message_node.add( "message_type", to_int(message_type()) );
         t_message_node.add( "encoding", interpret_encoding() );
         t_message_node.add( "timestamp", f_timestamp );
         t_message_node.add( "sender_info", get_sender_info() );
@@ -623,7 +623,7 @@ namespace dripline
         a_os << "Routing key: " << a_message.routing_key() << '\n';
         a_os << "Correlation ID: " << a_message.correlation_id() << '\n';
         a_os << "Reply To: " << a_message.reply_to() << '\n';
-        a_os << "Message Type: " << to_uint(a_message.message_type()) << '\n';
+        a_os << "Message Type: " << to_int(a_message.message_type()) << '\n';
         a_os << "Encoding: " << a_message.get_encoding() << '\n';
         a_os << "Timestamp: " << a_message.timestamp() << '\n';
         a_os << "Sender Info:\n";

--- a/library/message.hh
+++ b/library/message.hh
@@ -383,14 +383,14 @@ namespace dripline
 
     inline void msg_request::derived_modify_amqp_message( amqp_message_ptr /*a_amqp_msg*/, AmqpClient::Table& a_properties ) const
     {
-        a_properties.insert( AmqpClient::TableEntry( "message_operation", AmqpClient::TableValue(to_uint(f_message_operation)) ) );
+        a_properties.insert( AmqpClient::TableEntry( "message_operation", AmqpClient::TableValue(to_int(f_message_operation)) ) );
         a_properties.insert( AmqpClient::TableEntry( "lockout_key", AmqpClient::TableValue(string_from_uuid(lockout_key())) ) );
         return;
     }
 
     inline void msg_request::derived_modify_message_param( scarab::param_node& a_message_node ) const
     {
-        a_message_node.add( "message_operation", to_uint(f_message_operation) );
+        a_message_node.add( "message_operation", to_int(f_message_operation) );
         a_message_node.add( "lockout_key", string_from_uuid(lockout_key()) );
         return;
     }

--- a/testing/test_messages.cc
+++ b/testing/test_messages.cc
@@ -77,7 +77,7 @@ TEST_CASE( "message", "[message]" )
     REQUIRE( t_msg_node["correlation_id"]().as_string() == t_req_ptr->correlation_id() );
     REQUIRE( t_msg_node["message_id"]().as_string() == t_req_ptr->message_id() );
     REQUIRE( t_msg_node["reply_to"]().as_string() == t_req_ptr->reply_to() );
-    REQUIRE( t_msg_node["message_type"]().as_uint() == to_uint(t_req_ptr->message_type()) );
+    REQUIRE( t_msg_node["message_type"]().as_int() == to_int(t_req_ptr->message_type()) );
     REQUIRE( t_msg_node["encoding"]().as_string() == "application/json" );
     REQUIRE( t_msg_node["timestamp"]().as_string() == t_req_ptr->timestamp() );
 


### PR DESCRIPTION
In the Dripline protocol specification, the `message_type`, `message_operation`, and `return_code` are specified as `integer`, however, in the dripline-cpp source, in `message.cc`, these parameters are received with `GetUInt32()`, which accepts only unsigned integers (RabbitMQ data types `B`, `s`, `i`) and throws a boost exception (confusing!) if the value is a signed integer (RabbitMQ data types `b`, `u`, `I`), including `0`. This can be easily solved by replacing `.GetUInt32()` with `.GetInteger()` (three in message.cc) which accepts all the integer types. Some RabbitMQ libraries cannot easily write an unsigned `0`, so if this change could be made on the dripline side, it would be very helpful.

This change has been tested with the `librabbitmq-dev` used in the `3.12.1-slim-bookworm` container, which is used in the current main branch of dripline-cpp.